### PR TITLE
Publish-npm workflow version upgrade

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,24 +10,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - name: Echo payload
+        run: echo ${{ github.event.client_payload.message.tag }}
       - name: NPM-Version
-        uses: Reedyuk/NPM-Version@1.0.1
+        uses: Reedyuk/NPM-Version@1.1.1
         with:
           version: ${{ github.event.client_payload.message.tag }}
           package: ./
-      - name: Echo payload
-        run: echo ${{ github.event.client_payload.message.tag }}
       - name: Add & Commit
-        uses: EndBug/add-and-commit@v5.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: EndBug/add-and-commit@v9
       - run: npm run-script build
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,24 +1,15 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Version Update
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
 on:
   repository_dispatch:
     types:
       - publish npm package
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
@@ -26,23 +17,16 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - name: NPM-Version
-        # You may pin to the exact commit or the version.
-        # uses: Reedyuk/NPM-Version@9b08a57f534ead28c49f7b57665fe9f6d048ff74
         uses: Reedyuk/NPM-Version@1.0.1
         with:
-          # This will be the version you want to set in the package.json file
           version: ${{ github.event.client_payload.message.tag }}
-          # The location of the package.json file, defaults to current directory.
           package: ./
       - name: Echo payload
         run: echo ${{ github.event.client_payload.message.tag }}
       - name: Add & Commit
-        # You may pin to the exact commit or the version.
-        # uses: EndBug/add-and-commit@b5dec7ea7647ed6edf307ec828d3aeb6bca69f63
         uses: EndBug/add-and-commit@v5.1.0
         env:
-          # This is necessary in order to push a commit to the repo
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run-script build
       - run: npm publish
         env:


### PR DESCRIPTION
## Description

publish-npm gh actions workflow 를 업데이트

* https://github.com/iCloudHospital/iCloudHospital/issues/272
* https://github.com/iCloudHospital/ch-api-client-typescript2/pull/1 와 수정사항은 거의 동일합니다~
* 사용 중인 구버전 workflow 버전 업데이트
* `secrets.GITHUB_TOKEN` 와 같은 코드 더이상 사용하지 않도록 처리
* 불필요한 주석 삭제

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Build (`npm run build`) was run locally
- [x] Mention an issue number e.g. #5379
- [ ] Docs have been reviewed and added / updated if needed

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other (please describe): Version upgrade
