### PR TITLE
ci: remove n8n webhook notification

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,14 +29,3 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
-      - name: Wait 10 minutes
-        run: sleep 600
-  
-      - name: Send HTTP request after publish
-        run: |
-            curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"package": "ch-admin-api-client-typescript"}' \
-            https://n8n.icloudhospital.com/webhook/github-api-release


### PR DESCRIPTION
## Summary

Remove the 10-minute sleep and n8n webhook HTTP request after NPM publish.

## Changes

- Removed `Wait 10 minutes` step (sleep 600)
- Removed `Send HTTP request after publish` step (curl to n8n webhook)